### PR TITLE
[5] More clean-up after repo rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Base web service project in Go, currently aiming for basic http api implementati
 
 End goal is to have a single project that could be run using either gRPC or REST api.
 
-# Requirements
+## Requirements
 
 - Go v1.14
 - make
 
-# Environment Variables
+## Environment Variables
 
 - `HTTP_PORT`: 80
 - `HTTP_HOST`: localhost
 - `LOG_LEVEL`: debug
 
-# Usage
+## Usage
 
 Only need to clone the repo and run
 

--- a/app/service/main.go
+++ b/app/service/main.go
@@ -7,18 +7,21 @@ import (
 	"github.com/sergionunezgo/goservice/internal/logger"
 )
 
+// Config defines the values that can be loaded from env vars or other config files.
 type Config struct {
 	Port     int
 	Host     string
 	LogLevel string
 }
 
+// Service defines the methods that are required to operate a web service.
 type Service interface {
 	Start() error
 	Close() error
 }
 
+// New will return a Service that can be used to handle client requests.
 func New(cfg *Config) Service {
 	logger.Log.Info("initializing api service")
-	return webserver.NewHttpService(cfg.Host, strconv.Itoa(cfg.Port))
+	return webserver.NewHTTPService(cfg.Host, strconv.Itoa(cfg.Port))
 }

--- a/app/service/webserver/http_service.go
+++ b/app/service/webserver/http_service.go
@@ -21,11 +21,15 @@ func (lf logFunc) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.H
 	next(rw, r)
 }
 
-type HttpService struct {
+// HTTPService is the struct that will hold references to all necessary data for
+// running an http server.
+type HTTPService struct {
 	srv *http.Server
 }
 
-func NewHttpService(host string, port string) *HttpService {
+// NewHTTPService will run the setup process and create a HTTPService that can be
+// used to run a http api.
+func NewHTTPService(host string, port string) *HTTPService {
 	r := mux.NewRouter().StrictSlash(true)
 	setupRoutes(r)
 
@@ -42,17 +46,20 @@ func NewHttpService(host string, port string) *HttpService {
 		IdleTimeout:  time.Second * 60,
 	}
 
-	return &HttpService{
+	return &HTTPService{
 		srv: srv,
 	}
 }
 
-func (as *HttpService) Start() error {
+// Start will begin listening on the host:port for requests.
+// Blocking call.
+func (as *HTTPService) Start() error {
 	logger.Log.Infof("service listening on address: %v", as.srv.Addr)
 	return as.srv.ListenAndServe()
 }
 
-func (as *HttpService) Close() error {
+// Close will teardown/close any resources used by this http service.
+func (as *HTTPService) Close() error {
 	logger.Log.Info("ApiService Close method executed")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/gorilla/mux v1.7.4
 	github.com/pkg/errors v0.9.1
-	github.com/sergionunezgo/gorest v0.0.0-20200728053535-34e7fe647f68
 	github.com/urfave/cli v1.22.4
 	github.com/urfave/negroni v1.0.0
 	go.uber.org/zap v1.15.0

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,4 @@
-// package logger represents a generic logging interface
+// Package logger represents a generic logging interface
 package logger
 
 // Log is a package level variable, every program should access logging function through "Log"


### PR DESCRIPTION
Add more comments to exported methods and types.
Update readme.
Remove reference to old repo in go.mod.